### PR TITLE
Persist colors between visits

### DIFF
--- a/site/components/Colors.js
+++ b/site/components/Colors.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+const localStorageExists = window && window.localStorage;
+
 const Box = styled.div`
   width: 100%;
   max-width: 990px;
@@ -57,7 +59,6 @@ const TextInput = styled.input`
 
   outline: none;
   transition: border 200ms;
-
 `;
 
 const Button = styled.button`
@@ -103,11 +104,22 @@ class Colors extends React.Component {
       fg: '#fff',
       fg2: '#efefef',
     };
+
+    if (localStorageExists) {
+      const colors = window.localStorage.getItem('colors');
+      if (colors) {
+        this.state = JSON.parse(colors);
+      }
+    }
   }
 
   render() {
     const { active, applyColors, resetColors } = this.props;
     const { bg, fg, fg2 } = this.state;
+
+    if (localStorageExists) {
+      window.localStorage.setItem('colors', JSON.stringify(this.state));
+    }
 
     return (
       <Box active={active}>
@@ -141,21 +153,20 @@ class Colors extends React.Component {
           />
         </Input>
 
-        <Reset onClick={() => {
-          this.setState({
-            bg: '#1e1e1e',
-            fg: '#fff',
-            fg2: '#efefef',
-          });
-          resetColors();
-        }}
+        <Reset
+          onClick={() => {
+            this.setState({
+              bg: '#1e1e1e',
+              fg: '#fff',
+              fg2: '#efefef',
+            });
+            resetColors();
+          }}
         >
           Reset
         </Reset>
 
-        <Button onClick={() => applyColors(this.state)}>
-          Apply
-        </Button>
+        <Button onClick={() => applyColors(this.state)}>Apply</Button>
       </Box>
     );
   }

--- a/site/components/Colors.js
+++ b/site/components/Colors.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const localStorageExists = window && window.localStorage;
+let localStorageExists = false;
+
+try {
+  localStorageExists = window && window.localStorage;
+} catch {}
 
 const Box = styled.div`
   width: 100%;


### PR DESCRIPTION
👋 I really love this icon set. 

I find myself coming back often to update more of my icons, but I've been a little frustrated about having to re-add the colors every time. 

This PR just remembers people's choice between visits. The implementation is _very_ naive and I can update it to be more robust if you prefer.  

<details>
 <summary>Here's the icons in all their glory if you wanna see my setup</summary>

![image](https://user-images.githubusercontent.com/3087225/57183086-c5300b80-6e75-11e9-923e-c4f4b639049a.png)


</details>